### PR TITLE
Add form-adapter blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ save() {
 }
 ```
 
-### Configure Adapter
+### Configuration
 
 By default, `ember-fit-form` expects Changeset models. To setup your default Model type, you should configure the component through `config/environment`:
 
@@ -85,9 +85,6 @@ In the case that your forms use mixed Models throughout your application, you ca
   {{!-- form content --}}
 {{/fit-form}}
 ```
-
-#### Custom Adapters
-_Coming Soon_
 
 ## API
 * Actions
@@ -512,3 +509,34 @@ form.get('didValidate'); // true
 ```
 
 **[⬆️ back to top](#api)**
+
+### Custom Adapters
+Generate a form adapter
+> $ ember generate form-adapter foo-bar
+
+This creates `app/form-adapters/foo-bar.js` and a unit test at `tests/unit/form-adapters/foo-bar-test.js`. By default, the form-adapter extends the `base` adapter. 
+
+#### Example - extend `ember-changeset` form-adapter
+
+In this example, we'll extend the `ember-changeset` form-adapter. We will overwrite the default `oncancel` action to never call `rollbackAttributes()` on the Changesets.
+
+- Generate `form-adapter`
+  > ember g form-adapter ember-changeset/no-rollbacks
+
+- Extend the `ember-changeset` `form-adapter`
+  ``` js
+  // app/form-adapters/ember-changeset/no-rollbacks;
+  import EmberChangesetAdapter from 'ember-fit-form/form-adapters/ember-changeset';
+  export default EmberChangesetAdapter.extend({
+    oncancel() { /* noop - ie. no rollbackAttributes */ }
+  });
+  ```
+
+- Define adapter on component or [configuration](#configuration)
+  ```hbs
+  {{!-- my-template.hbs --}}
+  {{#fit-form changeset adapter="ember-changeset/no-rollbacks"}}
+    {{!-- other form content --}}
+  {{/fit-form}}
+  ```
+

--- a/addon/services/fit-form.js
+++ b/addon/services/fit-form.js
@@ -57,6 +57,8 @@ export default Service.extend({
     const localAdapter = getOwner(this).lookup(`form-adapter:${dasherizedAdapterName}`);
     const adapter = localAdapter ? localAdapter : availableAdapter;
 
+    assert(`[fit-form] Could not find a form adapter named ${name}`, adapter);
+
     set(cachedAdapters, name, adapter);
 
     return adapter;

--- a/blueprints/form-adapter-test/files/tests/unit/form-adapters/__test__.js
+++ b/blueprints/form-adapter-test/files/tests/unit/form-adapters/__test__.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('form-adapter:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/blueprints/form-adapter-test/index.js
+++ b/blueprints/form-adapter-test/index.js
@@ -1,0 +1,10 @@
+/* eslint-env node */
+
+module.exports = {
+  description: 'Generates a form-adapter unit test',
+  locals: function(options) {
+    return {
+      friendlyTestDescription: options.entity.name + ' adapter'
+    };
+  }
+};

--- a/blueprints/form-adapter/files/__root__/form-adapters/__name__.js
+++ b/blueprints/form-adapter/files/__root__/form-adapters/__name__.js
@@ -1,0 +1,52 @@
+<%= importStatement %>
+
+export default <%= baseClass %>.extend({
+  // Fit-Form Attributes
+  /*
+   * isDirty: false,
+   * isInvalid: false,
+   * isUnsubmittable: false,
+   */
+
+  // Fit-Form Action Hooks
+  /*
+   * oncancel() {
+   *
+   * },
+   *
+   * onerror() {
+   *
+   * },
+   *
+   * oninvalid() {
+   *
+   * },
+   *
+   * onsuccess() {
+   *
+   * },
+   *
+   * onsubmit() {
+   *
+   * },
+   *
+   * onvalidate() {
+   *
+   * }
+   */
+
+  // Fit-Form Event Handler Hooks
+  /*
+   * onkeydown() {
+   *
+   * },
+   *
+   * onkeypress() {
+   *
+   * },
+   *
+   * onkeyup() {
+   *
+   * },
+   */
+});

--- a/blueprints/form-adapter/index.js
+++ b/blueprints/form-adapter/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  description: 'Generates a fit-form adapter',
+
+  locals: function() {
+    var importStatement = "import BaseAdapter from 'ember-fit-form/form-adapters/base';";
+    var baseClass = 'BaseAdapter';
+
+    return {
+      importStatement: importStatement,
+      baseClass: baseClass
+    };
+  }
+};


### PR DESCRIPTION
## Purpose
Create form-adapters so that addon consumers can create custom adapters. This could allow users to overwrite or extend existing adapters. By default it extends from the base adapter Fixes #11 

## Usage
> ember g form-adapter <name>

## Example
In this example, we'll look at what it would take to extend the `ember-changeset` form-adapter. We will overwrite the default `oncancel` action to never call `rollbackAttributes()` on the Changesets.

- Generate `form-adapter`
  > ember g form-adapter ember-changeset/no-rollbacks

- Extend the `ember-changeset` `form-adapter`
  ``` js
  // app/form-adapters/ember-changeset/no-rollbacks;
  import EmberChangesetAdapter from 'ember-fit-form/form-adapters/ember-changeset';
  export default EmberChangesetAdapter.extend({
    oncancel() { /* noop - ie. no rollbackAttributes */ }
  });
  ```

- Define adapter on component
  ```hbs
  {{!-- my-template.hbs --}}
  {{#fit-form changeset adapter="ember-changeset/no-rollbacks"}}
    {{!-- other form content --}}
    <button {{form.cancel}} disabled={{form.isCancelling}}>
      {{if form.isCancelling "Cancelling..." "Cancel"}}
    </button>
  {{/fit-form}}
  ```

## Learning
Took inspiration from blueprint structure in [ember-metrics#metrics-adapters](https://github.com/poteto/ember-metrics/tree/master/blueprints)